### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,9 @@
 
 # Author: techgaun
 
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 red='\033[0;31m'
 green='\033[0;32m'
 nc='\033[0m'
@@ -43,12 +46,11 @@ msg "Created temp directory: ${TMP_DIR}"
 msg "Moving subdir: ${PROJECT_RELATIVE_PATH} to temp dir: ${TMP_DIR}"
 mv "${PROJECT_PATH}" "${TMP_DIR}"
 
-msg "Cleaning and re-creating build directory"
-rm -rf "${BUILD_DIR}"
-mkdir -p "${BUILD_DIR}"
+msg "Cleaning build directory"
+rm -rf "${BUILD_DIR}"/*
 
 msg "Moving project directory from ${TMP_DIR} to ${BUILD_DIR}"
-mv -T "${TMP_DIR}/${PROJECT_NAME}" "${BUILD_DIR}"
+mv "${TMP_DIR}/${PROJECT_NAME}"/* "${BUILD_DIR}"
 rm -rf "${TMP_DIR}"
 
 exit 0

--- a/bin/compile
+++ b/bin/compile
@@ -2,6 +2,8 @@
 
 # Author: techgaun
 
+set -e
+
 # Ensure wildcards in globs match dotfiles too.
 shopt -s dotglob
 


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Subdir to Root buildpack app detected
remote:        Creating temp directory
remote:        Created temp directory: /tmp/codon/tmp/cache/subrootS7COO
remote:        Moving subdir: frontend to temp dir: /tmp/codon/tmp/cache/subrootS7COO
remote:        Cleaning and re-creating build directory
remote: rm: cannot remove '/app': Read-only file system
remote:        Moving project directory from /tmp/codon/tmp/cache/subrootS7COO to /app
remote: mv: inter-device move failed: '/tmp/codon/tmp/cache/subrootS7COO/frontend' to '/app'; unable to remove target: Read-only file system
```

A fix for this compatibility issue has been merged into the upstream repository from which this one is forked:
https://github.com/techgaun/heroku-buildpack-subdir-to-root/pull/6

This PR merges the changes from the upstream repository back to this fork, so as to avoid any disruption to your builds in the future.

If you would like to avoid the merge commit from this PR (so that the two repository's Git histories do not diverge), then I'd recommend closing this PR as unmerged, and instead pulling upstream directly into `master` of this repo.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
https://github.com/techgaun/heroku-buildpack-subdir-to-root/issues/5

I'm also happy to answer any questions you may have via discussion on this PR :-)